### PR TITLE
Made compatible with Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,6 @@ addons:
 install:
   - pip install -U .
 before_script:
+  - pip install psycopg2cffi
   - psql -U postgres -c "CREATE DATABASE pq_test"
 script:  python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+python:
+  - "2.7"
+  - "3.3"
+cache:
+  apt: true
+addons:
+  postgresql: "9.3"
+install:
+  - pip install -U .
+before_script:
+  - psql -U postgres -c "CREATE DATABASE pq_test"
+script:  python setup.py test

--- a/pq/__init__.py
+++ b/pq/__init__.py
@@ -93,7 +93,15 @@ class Queue(object):
     logger = getLogger('pq')
 
     converters = {
-        'pickle': (pickle.dumps, lambda data: pickle.loads(str(data))),
+        'pickle': (
+            #
+            # Pickle protocol 0 claims to be ASCII, but it outputs
+            # characters outside of range(128). So, we treat it
+            # like Latin-1 so that it can encoded into JSON UTF-8.
+            #
+            lambda data: pickle.dumps(data, 0).decode('latin-1'),
+            lambda data: pickle.loads(data.encode('latin-1'))
+            ),
     }
 
     dumps = loads = staticmethod(lambda data: data)

--- a/pq/__init__.py
+++ b/pq/__init__.py
@@ -1,5 +1,10 @@
 import os
-import cPickle as pickle
+import sys
+
+if sys.version_info[0] == 2:
+    import cPickle as pickle
+else:
+    import pickle as pickle
 
 from contextlib import contextmanager
 from datetime import datetime

--- a/pq/__init__.py
+++ b/pq/__init__.py
@@ -67,8 +67,15 @@ class QueueIterator(object):
     def __iter__(self):
         return self
 
-    def next(self):
+    def __next__(self):
+        ''' Python 3 iterator.
+        '''
         return self.queue.get(timeout=self.timeout)
+
+    def next(self):
+        ''' Python 2 iterator.
+        '''
+        return QueueIterator.__next__(self)
 
 
 class Queue(object):

--- a/pq/tests.py
+++ b/pq/tests.py
@@ -251,7 +251,7 @@ class QueueTest(BaseTestCase):
         queue.put(data)
 
         def target():
-            for i in xrange(5):
+            for i in range(5):
                 sleep(0.2)
                 queue.put(data)
 
@@ -298,10 +298,10 @@ class QueueTest(BaseTestCase):
         def put(iterations=iterations):
             threads.append(current_thread())
             event.wait()
-            for i in xrange(iterations):
+            for i in range(iterations):
                 queue.put({})
 
-        for i in xrange(self.base_concurrency):
+        for i in range(self.base_concurrency):
             Thread(target=put).start()
 
         while len(threads) < self.base_concurrency:
@@ -327,7 +327,7 @@ class QueueTest(BaseTestCase):
                 if item is None:
                     break
 
-        for i in xrange(self.base_concurrency):
+        for i in range(self.base_concurrency):
             Thread(target=get).start()
 
         while len(threads) < self.base_concurrency:
@@ -387,12 +387,12 @@ class QueueTest(BaseTestCase):
         warmup = '__pypy__' in sys.builtin_module_names
         c = self.base_concurrency
 
-        for x in xrange(1 + int(warmup)):
-            cs = [[] for i in xrange(c * 2)]
+        for x in range(1 + int(warmup)):
+            cs = [[] for i in range(c * 2)]
 
             threads = (
-                [Thread(target=producer) for i in xrange(c)],
-                [Thread(target=consumer, args=(cs[i], )) for i in xrange(c)],
+                [Thread(target=producer) for i in range(c)],
+                [Thread(target=consumer, args=(cs[i], )) for i in range(c)],
             )
 
             active = ([], [])
@@ -443,7 +443,7 @@ class QueueTest(BaseTestCase):
 
         def producer():
             ident = current_thread().ident
-            for i in xrange(100):
+            for i in range(100):
                 queue.put((ident, i))
 
         consumed = []
@@ -457,8 +457,8 @@ class QueueTest(BaseTestCase):
                     consumed.append(tuple(d.data))
 
         c = self.base_concurrency
-        producers = [Thread(target=producer) for i in xrange(c * 2)]
-        consumers = [Thread(target=consumer) for i in xrange(c)]
+        producers = [Thread(target=producer) for i in range(c * 2)]
+        consumers = [Thread(target=consumer) for i in range(c)]
 
         for t in producers:
             t.start()

--- a/pq/utils.py
+++ b/pq/utils.py
@@ -132,17 +132,17 @@ class Literal(object):
     __slots__ = "s",
 
     def __init__(self, s):
-        self.s = str(s)
+        self.s = str(s).encode('utf-8')
 
     def __conform__(self, quote):
         return self
 
     def __str__(self):
-        return self.s
+        return self.s.decode('utf-8')
 
     @classmethod
     def mro(cls):
         return (object, )
 
     def getquoted(self):
-        return str(self)
+        return self.s

--- a/pq/utils.py
+++ b/pq/utils.py
@@ -76,7 +76,7 @@ def convert_time_spec(spec):
     if spec is None:
         return
 
-    if isinstance(spec, basestring):
+    if isinstance(spec, str) or isinstance(spec, unicode):
         m = _re_timedelta.match(spec)
         if m is None:
             raise ValueError(spec)


### PR DESCRIPTION
Fixes for Python 3 compatibility in a few areas:

* `str` vs. `bytes` issues.
* `pickle` vs. `cPickle` imports.
* `xrange` and `basestring` usage.
* Iterator protocol usage.
* Pickle vs. JSON compatibility.

Also added Travis CI configuration to close #3, and [verified that all tests pass](https://travis-ci.org/migurski/pq/builds/62006276). Would love to see this released to PyPI soon, using it in a project with Python 3!