### PR TITLE
Quote queue name within `LISTEN` statement.

### DIFF
--- a/pq/__init__.py
+++ b/pq/__init__.py
@@ -234,7 +234,7 @@ class Queue(object):
             yield self.conn
 
     def _listen(self, cursor):
-        cursor.execute("LISTEN %s", (Literal(self.name), ))
+        cursor.execute('LISTEN "%s"', (Literal(self.name), ))
 
     @prepared
     def _put_item(self, cursor):


### PR DESCRIPTION
This avoids queue name to clash with reserved keywords, such as
`default`.