### PR TITLE
Add encoding when reading README and CHANGES files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,8 @@ setup(
     author_email='mborch@gmail.com',
     description=__doc__,
     long_description='\n\n'.join((
-        open('README.rst').read(),
-        open('CHANGES.rst').read()
+        open('README.rst', encoding='utf-8').read(),
+        open('CHANGES.rst', encoding='utf-8').read()
     )),
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
Trying to install `pq` with Python 3.5 on a Ubuntu 16.04 box I get this error:
```
$ pip install --upgrade pq==1.4
Collecting pq==1.4
  Using cached pq-1.4.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-tpwv5kvk/pq/setup.py", line 16, in <module>
        open('README.rst').read(),
      File "/home/ubuntu/venv/lib/python3.5/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 532: ordinal not in range(128)

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-tpwv5kvk/pq/
```

The proposed patch uses an explicit UTF-8 encoding when reading the `README.rst` and `CHANGES.rst` files in `setup.py`, which fixes the problem.
