### PR TITLE
Fix non-ascii char in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ The system uses a single table that holds all jobs across queues; the
 specifics are easy to customize.
 
 The system currently supports only the `psycopg2
-<https://pypi.python.org/pypi/psycopg2>`_ database driver – or
+<https://pypi.python.org/pypi/psycopg2>`_ database driver - or
 `psycopg2cffi <https://pypi.python.org/pypi/psycopg2cffi>`_ for PyPy.
 
 The basic queue implementation is similar to Ryan Smith's


### PR DESCRIPTION
This non-ascii char sometimes causes `pip` fail to install `pq`

```
  Downloading pq-1.4.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-c3_hpt94/pq/setup.py", line 16, in <module>
        open('README.rst').read(),
      File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 532: ordinal not in range(128)
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-c3_hpt94/pq/
```