### PR TITLE
Add create.sql to package data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     description=__doc__,
     long_description='\n\n'.join(map(readfile, ('README.rst', 'CHANGES.rst'))),
     packages=find_packages(),
+    package_data={'': ['create.sql']},
     include_package_data=True,
     zip_safe=False,
     platforms='any',


### PR DESCRIPTION
Distribution does not currently deploy create.sql (with pip 9.0.1).