### PR TITLE
Package: switch to MANIFEST.in.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.rst CHANGES.rst pq/create.sql

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ setup(
     description=__doc__,
     long_description='\n\n'.join(map(readfile, ('README.rst', 'CHANGES.rst'))),
     packages=find_packages(),
-    package_data={'': ['create.sql']},
     include_package_data=True,
     zip_safe=False,
     platforms='any',


### PR DESCRIPTION
This is a follow up of: https://github.com/malthe/pq/pull/22
I experimented with `package_data` and even `data_files`, but after all I failed to get `sdist` to build a valid package with `create.sql` and `CHANGES.rst`.

Finally I got to MANIFEST approach: https://docs.python.org/2/distutils/sourcedist.html#manifest-related-options

And got the package successfully built:
```
/t/pq ❯  python setup.py sdist upload -r private                                                                                                  master ✱ ◼
/usr/local/lib/python2.7/dist-packages/setuptools/dist.py:334: UserWarning: Normalizing '1.5-dev' to '1.5.dev0'
  normalized_version,
running sdist
running egg_info
writing pq.egg-info/PKG-INFO
writing top-level names to pq.egg-info/top_level.txt
writing dependency_links to pq.egg-info/dependency_links.txt
reading manifest template 'MANIFEST.in'
writing manifest file 'pq.egg-info/SOURCES.txt'
running check
creating pq-1.5.dev0
creating pq-1.5.dev0/pq
creating pq-1.5.dev0/pq.egg-info
copying files to pq-1.5.dev0...
copying CHANGES.rst -> pq-1.5.dev0
copying MANIFEST.in -> pq-1.5.dev0
copying README.rst -> pq-1.5.dev0
copying setup.py -> pq-1.5.dev0
copying pq/__init__.py -> pq-1.5.dev0/pq
copying pq/create.sql -> pq-1.5.dev0/pq
copying pq/tasks.py -> pq-1.5.dev0/pq
copying pq/tests.py -> pq-1.5.dev0/pq
copying pq/utils.py -> pq-1.5.dev0/pq
copying pq.egg-info/PKG-INFO -> pq-1.5.dev0/pq.egg-info
copying pq.egg-info/SOURCES.txt -> pq-1.5.dev0/pq.egg-info
copying pq.egg-info/dependency_links.txt -> pq-1.5.dev0/pq.egg-info
copying pq.egg-info/not-zip-safe -> pq-1.5.dev0/pq.egg-info
copying pq.egg-info/top_level.txt -> pq-1.5.dev0/pq.egg-info
Writing pq-1.5.dev0/setup.cfg
Creating tar archive
removing 'pq-1.5.dev0' (and everything under it)
running upload
Submitting dist/pq-1.5.dev0.tar.gz to https://...privaterepo

```

