### PR TITLE
Fix ValueError('Encountered duplicate field name: timezone

### DIFF
--- a/pq/__init__.py
+++ b/pq/__init__.py
@@ -310,9 +310,9 @@ class Queue(object):
             AND dequeued_at IS NULL
             RETURNING
                id, data, length(data::text),
-               enqueued_at AT TIME ZONE 'utc',
-               schedule_at AT TIME ZONE 'utc',
-               expected_at AT TIME ZONE 'utc',
+               enqueued_at AT TIME ZONE 'utc' AS enqueued_at,
+               schedule_at AT TIME ZONE 'utc' AS schedule_at,
+               expected_at AT TIME ZONE 'utc' AS expected_at,
                (SELECT seconds FROM next_timeout)
 
         If `blocking` is set, the item blocks until an item is ready


### PR DESCRIPTION
When using `NamedTupleCursor` in psycopg2,  the `ValueError` is thrown because `enqueued_at AT TIME ZONE 'utc'`, `schedule_at AT TIME ZONE 'utc' `and `expected_at AT TIME ZONE 'utc' `have same alias which is `timezone`



```  File "/Users/meijunzhu/bosondata/reportr/reportr/__init__.py", line 75, in run_pq_worker
    for task in pq[queue]:
  File "/Users/meijunzhu/.pyenv/versions/3.6.1/envs/reportr/lib/python3.6/site-packages/pq/__init__.py", line 81, in __next__
    return self.queue.get(timeout=self.timeout)
  File "/Users/meijunzhu/.pyenv/versions/3.6.1/envs/reportr/lib/python3.6/site-packages/pq/__init__.py", line 176, in get
    cursor, block
  File "/Users/meijunzhu/.pyenv/versions/3.6.1/envs/reportr/lib/python3.6/site-packages/pq/utils.py", line 76, in wrapper
    return f(self, cursor, *args[arg_count:])
  File "/Users/meijunzhu/.pyenv/versions/3.6.1/envs/reportr/lib/python3.6/site-packages/pq/__init__.py", line 323, in _pull_item
    row = cursor.fetchone()
  File "/Users/meijunzhu/.pyenv/versions/3.6.1/envs/reportr/lib/python3.6/site-packages/psycopg2/extras.py", line 331, in fetchone
    nt = self.Record = self._make_nt()
  File "/Users/meijunzhu/.pyenv/versions/3.6.1/envs/reportr/lib/python3.6/site-packages/psycopg2/extras.py", line 371, in _make_nt
    return namedtuple("Record", [d[0] for d in self.description or ()])
  File "/Users/meijunzhu/.pyenv/versions/3.6.1/lib/python3.6/collections/__init__.py", line 413, in namedtuple
    raise ValueError('Encountered duplicate field name: %r' % name)
ValueError: Encountered duplicate field name: 'timezone'```