### PR TITLE
Fix bug when instantiating PQ with no queue_class

### DIFF
--- a/pq/__init__.py
+++ b/pq/__init__.py
@@ -48,7 +48,7 @@ class PQ(object):
             if factory is None:
                 factory = Queue
             return self.queues.setdefault(
-                name, self.queue_class(name, *self.params[0], **self.params[1])
+                name, factory(name, *self.params[0], **self.params[1])
             )
 
     def close(self):


### PR DESCRIPTION
Fix to the following issue that prevents pq working with default queue class.

```
>>> pq = PQ(conn)
>>> pq.create()
Traceback (most recent call last):
  File "/Users/<USER>/.local/share/virtualenvs/eg2-o6qwgJzB/lib/python3.6/site-packages/pq/__init__.py", line 46, in __getitem__
    return self.queues[name]
  File "/Users/<USER>/.local/share/virtualenvs/eg2-o6qwgJzB/lib/python3.6/weakref.py", line 137, in __getitem__
    o = self.data[key]()
KeyError: ''

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/<USER>/.local/share/virtualenvs/eg2-o6qwgJzB/lib/python3.6/site-packages/pq/__init__.py", line 59, in create
    queue = self['']
  File "/Users/<USER>/.local/share/virtualenvs/eg2-o6qwgJzB/lib/python3.6/site-packages/pq/__init__.py", line 52, in __getitem__
    name, self.queue_class(name, *self.params[0], **self.params[1])
TypeError: 'NoneType' object is not callable
```