### PR TITLE
Pull null-value prioritized tasks after those with a set priority

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+In next release ...
+
+- Change policy on task priority. Tasks with a null-value for
+  `expected_at` are now processed after items that have a value set.
+
 1.7.0 (2019-04-07)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -169,7 +169,8 @@ be expressed:
 
 This tells the queue processor to give priority to this item over an
 item expected at a later time, and conversely, to prefer an item with
-an earlier expected time.
+an earlier expected time. Note that items without a set priority are
+pulled last.
 
 The scheduling and priority options can be combined:
 

--- a/pq/__init__.py
+++ b/pq/__init__.py
@@ -294,7 +294,7 @@ class Queue(object):
                 WHERE
                   q_name = %(name)s AND
                   dequeued_at IS NULL
-                ORDER BY schedule_at nulls first, expected_at nulls first
+                ORDER BY schedule_at nulls first, expected_at nulls last
                 FOR UPDATE SKIP LOCKED
                 LIMIT 1
               ),

--- a/pq/tests.py
+++ b/pq/tests.py
@@ -140,10 +140,11 @@ class QueueTest(BaseTestCase):
         queue.put(1, None, "1s")
         queue.put(2, None, "2s")
         queue.put(3, None, "3s")
+        queue.put(6)
         queue.put(4, None, timedelta(seconds=4))
         queue.put(5, None, timedelta(seconds=5) + datetime.utcnow())
         t = time()
-        self.assertEqual(len(queue), 5)
+        self.assertEqual(len(queue), 6)
         for i, job in enumerate(queue):
             if job is None:
                 break
@@ -151,10 +152,15 @@ class QueueTest(BaseTestCase):
             self.assertEqual(i + 1, job.data)
             d = time() - t
             self.assertTrue(d < 1)
-            self.assertFalse(job.expected_at is None)
+            is_null = job.expected_at is None
+
+            if job.data == 6:
+                self.assertTrue(is_null)
+            else:
+                self.assertFalse(is_null)
 
         # We expect five plus the empty.
-        self.assertEqual(i, 5)
+        self.assertEqual(i, 6)
 
     def test_put_schedule_at_without_blocking(self):
         queue = self.make_one("test_schedule_at_non_blocking")


### PR DESCRIPTION
Previously, a task with an `expected_at` set to `None` would be pulled before a task with say, `expected_at` set to 0 (i.e. "immediately").