### PR TITLE
Ensure identifiers (prepared statement names and notify channels) are valid

### DIFF
--- a/pq/create.sql
+++ b/pq/create.sql
@@ -7,6 +7,7 @@ CREATE TABLE %(name)s (
   expected_at timestamptz,
   schedule_at timestamptz,
   q_name      text         NOT NULL CHECK (length(q_name) > 0),
+  q_key       text         NOT NULL CHECK (length(q_key) > 0),
   data        json         NOT NULL
 );
 
@@ -25,7 +26,7 @@ create index priority_idx_no_%(name)s on %(name)s
 drop function if exists pq_notify() cascade;
 
 create function pq_notify() returns trigger as $$ begin
-  perform pg_notify(new.q_name, '');
+  perform pg_notify(new.q_key, '');
   return null;
 end $$ language plpgsql;
 

--- a/pq/tests.py
+++ b/pq/tests.py
@@ -563,6 +563,20 @@ class QueueTest(BaseTestCase):
         self.assertRaises(ValueError, test)
         self.assertEqual(queue.get(), None)
 
+    def test_queue_name_with_space(self):
+        queue = self.make_one("test two")
+        queue.put({'foo': 'bar'})
+
+        with self.assertExecutionTime(lambda seconds: 0 < seconds < 0.1):
+            self.assertEqual(queue.get().data, {'foo': 'bar'})
+
+    def test_long_queue_name(self):
+        queue = self.make_one("a_name_longer_than_sixtythree_characters_long_at_least_after_prefixing")
+        queue.put({'foo': 'bar'})
+
+        with self.assertExecutionTime(lambda seconds: 0 < seconds < 0.1):
+            self.assertEqual(queue.get().data, {'foo': 'bar'})
+
 
 class TaskTest(BaseTestCase):
     queue_class = TaskQueue

--- a/pq/utils.py
+++ b/pq/utils.py
@@ -134,6 +134,7 @@ def transaction(conn, **kwargs):
 
     for notice in cursor.connection.notices:
         logger.warning(notice)
+    cursor.connection.notices.clear()
 
 
 class Literal(object):

--- a/pq/utils.py
+++ b/pq/utils.py
@@ -8,6 +8,8 @@ from functools import wraps
 from textwrap import dedent
 from logging import getLogger
 from datetime import datetime, timedelta
+from hashlib import sha256
+from base64 import b32encode
 
 
 PY2 = bool(sys.version_info[0] == 2)
@@ -17,6 +19,7 @@ logger = getLogger("pq")
 
 _re_format = re.compile(r'%\(([a-z]+)\)[a-z]')
 _re_timedelta = re.compile(r'(\d+)([smhd])')
+_re_identifier = re.compile(r'^[_a-z][_a-z0-9]*$', re.IGNORECASE)
 _timedelta_table = dict(s='seconds', m='minutes', h='hours', d='days')
 _statements = WeakKeyDictionary()
 
@@ -56,6 +59,7 @@ def prepared(f):
     def wrapper(self, cursor, *args):
         conn = cursor.connection
         name = fname % self.__dict__
+        identifier = unique_identifier(name)
         key = "_prepared_%s" % name
 
         try:
@@ -66,10 +70,10 @@ def prepared(f):
         if key not in prepared:
             prepared.add(key)
             d = self.__dict__.copy()
-            cursor.execute("PREPARE %s AS\n%s" % (name, query), d)
+            cursor.execute("PREPARE %s AS\n%s" % (identifier, query), d)
 
         params = args[:arg_count]
-        statement = "EXECUTE " + name
+        statement = "EXECUTE " + identifier
         if fargs is not None:
             statement += " " + fargs
         cursor.execute(statement, params or None)
@@ -152,3 +156,17 @@ class Literal(object):
 
     def getquoted(self):
         return self.s
+
+def unique_identifier(name, prefix='pq_'):
+    """Create a unique identifier from a name and a (non-empty) prefix.
+
+    ValueError is raised if prefix is not a valid postgresql identifier of maximum length 11 characters.
+    """
+
+    if len(prefix) > 11 or not _re_identifier.match(prefix):
+        raise ValueError(prefix)
+
+    # b32encode of 256 bits (32 bytes) is 56 bytes, but the final 4 are always padding ('====')
+    b32_digest = b32encode(sha256(name.encode()).digest())[:52]
+
+    return prefix + b32_digest.decode()


### PR DESCRIPTION
## What is the current behavior?

Queue names which are not syntactically valid postgresql identifiers (too long, or contain spaces) do not work (#43).

## What is the new behavior?

Identifiers are formed from base32-encoding the sha256 of the queue name, instead of the queue name itself. The base32 encoding fixes the invalid character issue, while the sha256 fixes the length limitation.

The first commit adds just the (failing) tests.

Note that a column is added to the queue table to store the identifier name in (it must be available to the trigger). The final commit adds automatic migration of the table in `create`. It requires postgresql 9.5+ to support the "create index if not exists" syntax.

## Checklist

Please make sure the following requirements are complete:

- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [ ] All automated checks pass (CI/CD)
