### PR TITLE
Get tasks in order of enqueueing if no other constraints given

### DIFF
--- a/pq/__init__.py
+++ b/pq/__init__.py
@@ -303,7 +303,7 @@ class Queue(object):
                 WHERE
                   q_name = %(name)s AND
                   dequeued_at IS NULL
-                ORDER BY schedule_at nulls first, expected_at nulls last
+                ORDER BY schedule_at nulls first, expected_at nulls last, id
                 FOR UPDATE SKIP LOCKED
                 LIMIT 1
               ),

--- a/pq/create.sql
+++ b/pq/create.sql
@@ -9,12 +9,12 @@ create table if not exists %(name)s (
 );
 
 create index if not exists priority_idx_%(name)s on %(name)s
-    (schedule_at nulls first, expected_at nulls first, q_name)
+      (schedule_at nulls first, expected_at nulls last, q_name)
     where dequeued_at is null
           and q_name = '%(name)s';
 
 create index if not exists priority_idx_no_%(name)s on %(name)s
-    (schedule_at nulls first, expected_at nulls first, q_name)
+    (schedule_at nulls first, expected_at nulls last, q_name)
     where dequeued_at is null
           and q_name != '%(name)s';
 


### PR DESCRIPTION
## What is the current behavior?

If neither `schedule_at` or `expected_at` is set for tasks, tasks are dequeued in an unspecified order. Typically a small number are dequeued in order, then a jump.

I know this is easily worked around (by specifying a constraint), but I think in-order dequeueing follows the principle of least surprise.

## What is the new behavior?

Tasks are dequeued in the order they are enqueued.

## Checklist

Please make sure the following requirements are complete:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [x] All automated checks pass (CI/CD)

I don't think this change requires new tests or documentation.