### PR TITLE
Always put connection back into pull

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Changes
   trigger) is required if using names longer than this limit. If not
   using, then no migration is required.
 
+- Return connections to the pool if an exception is raised while it is retrieved
+
 1.8.1 (2019-07-30)
 ------------------
 

--- a/pq/__init__.py
+++ b/pq/__init__.py
@@ -252,8 +252,10 @@ class Queue(object):
     def _conn(self):
         if self.pool:
             conn = self.pool.getconn()
-            yield conn
-            self.pool.putconn(conn)
+            try:
+                yield conn
+            finally:
+                self.pool.putconn(conn)
         else:
             yield self.conn
 

--- a/tests.py
+++ b/tests.py
@@ -123,6 +123,15 @@ class CursorTest(BaseTestCase):
         job = queue.get()
         self.assertEqual(job.data, {'foo': 'bar'})
 
+    def test_returning_connections(self):
+        try:
+            with self.pq['test'] as cursor:
+                self.assertTrue(self.pool._used)
+                raise Exception('test')
+        except:
+            pass
+        self.assertFalse(self.pool._used)
+
 
 class QueueTest(BaseTestCase):
     base_concurrency = 4


### PR DESCRIPTION
## What is the current behavior?

Connections are not put back into the pool if there is an exception
Related issue https://github.com/malthe/pq/issues/41

## What is the new behavior?

Connections now returned to the pool if there is an exception

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [ ] All automated checks pass (CI/CD)
