### PR TITLE
Update python packaging deps before CI'ing.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     - uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - run: python setup.py test
+    - run: python -m pip install --upgrade pip setuptools wheel && python setup.py test
       env:
         PQ_TEST_DB_PORT: ${{ job.services.postgres.ports[5432] }}
         PQ_TEST_DB_HOST: localhost


### PR DESCRIPTION
## What is the current behavior?

Pypy tests are failing.

## What is the new behavior?

Tests run fine only after we get the latest dependencies for packaging toolset (wheel, setuptools...).

## Checklist

Please make sure the following requirements are complete:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [x] All automated checks pass (CI/CD)
