### PR TITLE
Redo timeout handling in get()

### DIFF
--- a/pq/__init__.py
+++ b/pq/__init__.py
@@ -8,6 +8,7 @@ from select import select
 from logging import getLogger
 from hashlib import md5
 from weakref import WeakValueDictionary
+from time import time
 
 from .utils import (
     Literal, prepared, transaction, convert_time_spec, utc_format
@@ -94,11 +95,10 @@ class QueueIterator(object):
 class Queue(object):
     """Simple thread-safe transactional queue."""
 
-    # This timeout is used during iteration. If the timeout elapses
-    # and no item was pulled from the queue, the iteration loop
-    # returns ``None``.
+    # The default timeout used during iteration, if an explicit timeout is not
+    # passed to get(). If the timeout elapses and no item was pulled from the
+    # queue, the iteration loop returns ``None``.
     timeout = 1
-    last_timeout = None
 
     # Keyword arguments passed when creating a new cursor.
     cursor_kwargs = {}
@@ -166,9 +166,21 @@ class Queue(object):
             self.pool.closeall()
 
     def get(self, block=True, timeout=None):
-        """Pull item from queue."""
+        """Pull item from queue.
 
-        self.timeout = timeout or self.timeout
+        If the 'block' parameter is set (default), then the call will block
+        until an item is available or the timeout is reached. The default
+        timeout is 1 second; a timeout of 0 will block indefinitely.
+
+        If 'block' is False, the timeout setting is ignored and the call returns
+        immediately.
+
+        Returns None if no item is scheduled by the time the function returns.
+        """
+
+        if timeout is None:
+            timeout = self.timeout
+        deadline = time() + timeout # only used if timeout != 0 (not indefinite)
 
         while True:
             with self._transaction() as cursor:
@@ -183,15 +195,8 @@ class Queue(object):
                 ) = self._pull_item(
                     cursor, block
                 )
-                self.last_timeout = (
-                    seconds or self.last_timeout or self.timeout
-                )
 
             if data is not None:
-                # Reset the timeout if there's no estimation
-                if seconds is None or seconds < 0:
-                    self.last_timeout = self.timeout
-
                 decoded = self.decode(data)
 
                 return Job(
@@ -199,13 +204,25 @@ class Queue(object):
                     enqueued_at, schedule_at, expected_at, self.update
                 )
 
-            if not block:
-                return
+            cur_timeout = 0 if timeout == 0 else deadline - time()
 
-            self.last_timeout = min(self.last_timeout, self.timeout)
+            if not block or cur_timeout < 0:
+                return None
 
-            if not self._select(self.last_timeout):
-                block = False
+            if seconds is not None:
+                if seconds > 0:
+                    # An item awaiting schedule_at, don't wait past it
+                    cur_timeout = seconds if timeout == 0 else min(cur_timeout, seconds)
+                else:
+                    # Unclear: is it possible that seconds <= 0 and still no
+                    # item is returned above?  What does it mean? For now, redo
+                    # query immediately to either pull the item or get a new
+                    # estimate.
+                    self.logger.debug(f'unexpected estimate {seconds}s, redo query')
+                    continue
+
+            # Block until something happens, or timeout
+            self._select(cur_timeout)
 
     def put(self, data, schedule_at=None, expected_at=None):
         """Put item into queue.

--- a/tests.py
+++ b/tests.py
@@ -241,7 +241,8 @@ class QueueTest(BaseTestCase):
         queue.put({'boo': 'baz'}, timedelta(seconds=4) + datetime.utcnow())
 
         # We use a timeout of five seconds for this test.
-        def get(block=True): return queue.get(block, 5)
+        timeout = 5
+        def get(block=True): return queue.get(block, timeout)
 
         # First item is immediately available.
         self.assertEqual(get(False).data, {'bar': 'foo'})
@@ -257,7 +258,7 @@ class QueueTest(BaseTestCase):
 
         # This ensures the timeout has been reset
         with self.assertExecutionTime(
-                lambda seconds: queue.timeout < seconds < queue.timeout + 1,
+                lambda seconds: timeout < seconds < timeout + 1,
                 time(),
         ):
             self.assertEqual(get(), None)


### PR DESCRIPTION
## What is the new behavior?

Suggested fix for #53.

This is a request for comments, not tested yet. The reason is that I don't understand the previous implementation, especially why `last_timeout` was saved between calls. So, possibly, the new implementation might be misguided.

The new implementation only uses `self.timeout` as default value for timeout if not specified, never writes to it. `last_timeout` is removed completely. The timeout (`cur_timeout`) is recalculated every loop iteration to match the initial deadline.

The following are the intended timeout semantics:
- If `block=False`, the call returns immediately. Otherwise,
- If `timeout=None`, `self.timeout` is used (1s by default).
- If `timeout=0`, the call blocks indefinitely (until an item is ready)
- If `timeout>0`, the call blocks never returns early (unless an item is ready).

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [x] All automated checks pass (CI/CD)
