### PR TITLE
Return id of created job

### DIFF
--- a/pq/tasks.py
+++ b/pq/tasks.py
@@ -32,7 +32,7 @@ def task(
                 expected_at=_expected_at or expected_at,
             )
 
-            queue.put(
+            return queue.put(
                 dict(
                     function=f._path,
                     args=args,

--- a/tests.py
+++ b/tests.py
@@ -744,3 +744,13 @@ class TaskTest(BaseTestCase):
 
         self.assertEqual(test_value, 3)
         del test_value
+    
+    def test_task_id(self):
+        queue = self.make_one("jobs_task_id")
+        
+        @queue.task()
+        def job_handler():
+            return True
+        
+        assert job_handler() is not None
+        assert job_handler() + 1 == job_handler()


### PR DESCRIPTION
Useful for tracking job status outside of job

## What is the current behavior?

queue.put doesn't return anything

## What is the new behavior?

queue.put return id of new job

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [x] All automated checks pass (CI/CD)
