### PR TITLE
Passing job_id as first argument in tasks API

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -238,7 +238,7 @@ Tasks
     queue = pq['default']
 
     @queue.task(schedule_at='1h')
-    def eat(kind):
+    def eat(job_id, kind):
         print 'umm, %s apples taste good.' % kind
 
     eat('Cox')
@@ -251,7 +251,7 @@ Tasks
 .. code-block:: python
 
     @queue.task(schedule_at='1h', max_retries=2, retry_in='10s')
-    def eat(kind):
+    def eat(job_id, kind):
         # ...
 
 
@@ -261,6 +261,8 @@ Time expectations can be overriden at ``task`` call:
 
     eat('Cox', _expected_at='2m', _schedule_at='1m')
 
+
+** NOTE ** First positional argument is id of job. It's PK of record in PostgreSQL.
 
 Thread-safety
 =============

--- a/pq/tasks.py
+++ b/pq/tasks.py
@@ -85,7 +85,7 @@ class Queue(BaseQueue):
             ))
 
         try:
-            f(*data['args'], **data['kwargs'])
+            f(job.id, *data['args'], **data['kwargs'])
             return True
 
         except Exception as e:

--- a/tests.py
+++ b/tests.py
@@ -769,7 +769,7 @@ class TaskTest(BaseTestCase):
         new_job_id = job_handler()
         queue.work(True)
 
-        self.assertFalse(new_job_id is None)
+        self.assertNotEqual(new_job_id, 0)
         self.assertEqual(test_value, new_job_id)
 
         del test_value

--- a/tests.py
+++ b/tests.py
@@ -758,13 +758,18 @@ class TaskTest(BaseTestCase):
     def test_job_id(self):
         queue = self.make_one("jobs_task_executor_job_id")
         
-        current_job_id = None
+        global test_value
+        test_value = 0
+
         @queue.task()
         def job_handler(job_id):
-            global current_job_id
-            current_job_id = job_id
+            global test_value
+            test_value = job_id
         
         new_job_id = job_handler()
         queue.work(True)
+
         self.assertFalse(new_job_id is None)
-        self.assertEqual(current_job_id, new_job_id)
+        self.assertEqual(test_value, new_job_id)
+
+        del test_value

--- a/tests.py
+++ b/tests.py
@@ -607,7 +607,7 @@ class TaskTest(BaseTestCase):
     queue_class = TaskQueue
 
     @staticmethod
-    def job(increment):
+    def job(job_id, increment):
         global test_value
         test_value += increment
         return True
@@ -651,7 +651,7 @@ class TaskTest(BaseTestCase):
         queue = self.make_one("jobs")
 
         @queue.task(expected_at='1s')
-        def job_handler(value):
+        def job_handler(job_id, value):
             return value
 
         schedule_at = datetime.utcnow() - timedelta(seconds=5)
@@ -675,7 +675,7 @@ class TaskTest(BaseTestCase):
         test_value = 1
 
         @queue.task()
-        def job_handler(increment):
+        def job_handler(job_id, increment):
             global test_value
             test_value += increment
             return True
@@ -692,7 +692,7 @@ class TaskTest(BaseTestCase):
         queue = self.make_one("jobs")
 
         @queue.task()
-        def job_handler(value):
+        def job_handler(job_id, value):
             return value
 
         del queue.handler_registry[job_handler._path]
@@ -708,7 +708,7 @@ class TaskTest(BaseTestCase):
         test_value = 3
 
         @queue.task()
-        def job_handler(increment):
+        def job_handler(job_id, increment):
             if increment < 0:
                 raise Exception()
 
@@ -732,7 +732,7 @@ class TaskTest(BaseTestCase):
         test_value = 0
 
         @queue.task(max_retries=2, retry_in=None)
-        def job_handler(increment):
+        def job_handler(job_id, increment):
             global test_value
 
             test_value += increment
@@ -749,8 +749,22 @@ class TaskTest(BaseTestCase):
         queue = self.make_one("jobs_task_id")
         
         @queue.task()
-        def job_handler():
+        def job_handler(job_id):
             return True
         
         assert job_handler() is not None
         assert job_handler() + 1 == job_handler()
+
+    def test_job_id(self):
+        queue = self.make_one("jobs_task_executor_job_id")
+        
+        current_job_id = None
+        @queue.task()
+        def job_handler(job_id):
+            global current_job_id
+            current_job_id = job_id
+        
+        new_job_id = job_handler()
+        queue.work(True)
+        self.assertFalse(new_job_id is None)
+        self.assertEqual(current_job_id, new_job_id)


### PR DESCRIPTION
Related to https://github.com/malthe/pq/issues/58

## What is the current behavior?

There is no mechanism for getting id of current executing job in Task API.

## What is the new behavior?

Passing job.id as first positional argument in Task API.

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [x] All automated checks pass (CI/CD)
