### PR TITLE
Fix test_task_arguments forgotten parameter

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -638,7 +638,7 @@ class TaskTest(BaseTestCase):
         queue = self.make_one("jobs")
 
         @queue.task(None, expected_at='1s')
-        def job_handler(value):
+        def job_handler(job_id, value):
             return value
 
         job_handler('test')


### PR DESCRIPTION
Test was green because we are checking only `job` and `expected_at`, not exactly running job

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [x] All automated checks pass (CI/CD)
