### PR TITLE
Unwrap task function if wrapped

### DIFF
--- a/pq/tasks.py
+++ b/pq/tasks.py
@@ -77,7 +77,12 @@ class Queue(BaseQueue):
         f = self.handler_registry.get(function_path)
 
         if function_path not in self.handler_registry:
-            f = self.handler_registry[function_path] = locate(function_path)
+            f = locate(function_path)
+            
+            if hasattr(f, "__wrapped__"):
+                f = f.__wrapped__
+                
+            self.handler_registry[function_path] = f
 
         if f is None:
             return self.fail(job, data, KeyError(


### PR DESCRIPTION
## What is the current behavior?

I made a small example of the Task API and noticed this weird behaviour: If the process where I was running `queue.run()` from didn't explicitly import the `@queue.task`-decorated function (even if unused), then instead of executing tasks instead it would endlessly queue new tasks. 

This is because (I think) the wrapper gets registered instead of the function, so invoking it actually queues up a new task instead of invoking the task that's there. 

## What is the new behavior?

When storing a function in the registry, the `hasattr` check means that the _original_ function (at least, one level of the original function - not sure about stacked decorators, could use a `while:` loop?) will be used instead of the wrapper. This fixes the problem locally. 

## Checklist

Please make sure the following requirements are complete:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [ ] All automated checks pass (CI/CD)

^ will work on the above now but since it's a small patch I wanted to get this open to get people's thoughts 

Thanks, 

Tom
