### PR TITLE
fix pg14: EXTRACT returns `numeric`  instead of `float8`

### DIFF
--- a/pq/__init__.py
+++ b/pq/__init__.py
@@ -333,8 +333,8 @@ class Queue(object):
               enqueued_at AT TIME ZONE 'utc' AS enqueued_at,
               schedule_at AT TIME ZONE 'utc' AS schedule_at,
               expected_at AT TIME ZONE 'utc' AS expected_at,
-              (extract(
-                second FROM (
+              (date_part(
+                'second', (
                   (SELECT schedule_at - now() FROM selected))))
             FROM selected
 


### PR DESCRIPTION
From changelog https://www.postgresql.org/docs/14/release-14.html#id-1.11.6.11.4

> Change EXTRACT() to return type numeric instead of float8

pq uses extracted seconds as timeout in `select()` which expects float but numeric converted into Decimal https://www.psycopg.org/docs/usage.html#adaptation-of-python-values-to-sql-types